### PR TITLE
fix: add docs link to header (#1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,6 +379,7 @@ footer .copyright {
   <div class="nav-links">
     <a href="#features" class="nav-link">Features</a>
     <a href="#quickstart" class="nav-link">Quick Start</a>
+    <a href="/docs" class="nav-link">Docs</a>
     <a href="#about" class="nav-link">About</a>
     <a href="#quickstart" class="btn btn-outline btn-sm">&#9889; Get Started</a>
   </div>


### PR DESCRIPTION
## Summary

Adds a Docs link to the site header navigation, positioned between Quick Start and About links.

## Changes

- Added Docs link to nav-links container in index.html

## References

- Issue #1