### PR TITLE
feat: add sidecar flags to install scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -4,11 +4,15 @@
     Otterbot installer for Windows — https://otterbot.ai
 .DESCRIPTION
     Usage: irm https://otterbot.ai/install.ps1 | iex
-    Or:    .\install.ps1 [-Dir <path>] [-Beta] [-NoStart] [-Help]
+    Or:    .\install.ps1 [-Dir <path>] [-Beta] [-ComfyUI] [-Trellis] [-NoStart] [-Help]
 .PARAMETER Dir
     Install directory (default: $env:USERPROFILE\otterbot)
 .PARAMETER Beta
     Use the :beta image tag instead of :latest
+.PARAMETER ComfyUI
+    Include ComfyUI image generation sidecar
+.PARAMETER Trellis
+    Include TRELLIS 3D generation sidecar
 .PARAMETER NoStart
     Generate files but don't pull/start the container
 .PARAMETER Help
@@ -18,6 +22,8 @@
 param(
     [string]$Dir,
     [switch]$Beta,
+    [switch]$ComfyUI,
+    [switch]$Trellis,
     [switch]$NoStart,
     [switch]$Help
 )
@@ -51,6 +57,8 @@ Usage:
 Options:
   -Dir <path>   Install directory (default: ~\otterbot)
   -Beta         Use the beta image tag
+  -ComfyUI      Include ComfyUI image generation sidecar
+  -Trellis      Include TRELLIS 3D generation sidecar
   -NoStart      Generate files but don't start the container
   -Help         Show this help message
 
@@ -172,7 +180,16 @@ OTTERBOT_ALLOWED_ORIGIN=https://localhost:62626
 
 # ── Generate docker-compose.yml ──────────────────────────────────────────────
 
-@"
+# Build extra environment variables for sidecar URLs
+$extraEnv = ''
+if ($ComfyUI) {
+    $extraEnv += "`n      - OTTERBOT_COMFYUI_URL=http://comfyui:8188"
+}
+if ($Trellis) {
+    $extraEnv += "`n      - OTTERBOT_TRELLIS_URL=http://trellis:8080"
+}
+
+$compose = @"
 services:
   otterbot:
     image: ${Image}:${Tag}
@@ -188,11 +205,54 @@ services:
       - ENABLE_DESKTOP=`${ENABLE_DESKTOP:-true}
       - DESKTOP_RESOLUTION=`${DESKTOP_RESOLUTION:-1280x720x24}
       - SUDO_MODE=`${SUDO_MODE:-restricted}
-      - OTTERBOT_ALLOWED_ORIGIN=`${OTTERBOT_ALLOWED_ORIGIN:-}
+      - OTTERBOT_ALLOWED_ORIGIN=`${OTTERBOT_ALLOWED_ORIGIN:-}${extraEnv}
     restart: unless-stopped
-"@ | Set-Content -Path $composeFile -Encoding UTF8
+"@
 
-Write-Info "Generated docker-compose.yml (image tag: $Tag)"
+if ($ComfyUI) {
+    $compose += @"
+
+  comfyui:
+    image: ghcr.io/toosmooth/otterbot-comfyui:${Tag}
+    environment:
+      - CLI_ARGS=--listen 0.0.0.0 --port 8188
+      - COMFYUI_DATA_ROOT=/data
+    volumes:
+      - `${OTTERBOT_DATA_DIR:-./data}/comfyui:/data
+    expose:
+      - "8188"
+    restart: unless-stopped
+"@
+}
+
+if ($Trellis) {
+    $compose += @"
+
+  trellis:
+    image: ghcr.io/toosmooth/otterbot-trellis:${Tag}
+    environment:
+      - TRELLIS_DATA_ROOT=/data
+      - TRELLIS_PORT=8080
+      - TRELLIS_MODEL_REF=microsoft/TRELLIS-image-large
+      - TRELLIS_INFERENCE_CMD=
+      - ENABLE_BLENDER_POSTPROCESS=true
+    volumes:
+      - `${OTTERBOT_DATA_DIR:-./data}/trellis:/data
+    expose:
+      - "8080"
+    restart: unless-stopped
+"@
+}
+
+$compose | Set-Content -Path $composeFile -Encoding UTF8
+
+$sidecarsMsg = ''
+if ($ComfyUI -or $Trellis) {
+    $sidecarsMsg = ' + sidecars:'
+    if ($ComfyUI) { $sidecarsMsg += ' comfyui' }
+    if ($Trellis) { $sidecarsMsg += ' trellis' }
+}
+Write-Info "Generated docker-compose.yml (image tag: $Tag$sidecarsMsg)"
 
 # ── Pull & start ─────────────────────────────────────────────────────────────
 
@@ -220,6 +280,12 @@ Write-Host ''
 Write-Host "  URL:      https://localhost:62626  (self-signed certificate)"
 Write-Host "  Data:     $dataDir"
 Write-Host "  Config:   $envFile"
+if ($ComfyUI) {
+    Write-Host "  ComfyUI:  enabled (port 8188 internal)"
+}
+if ($Trellis) {
+    Write-Host "  TRELLIS:  enabled (port 8080 internal)"
+}
 Write-Host ''
 Write-Host "  Stop:     cd $InstallDir; docker compose down"
 Write-Host "  Start:    cd $InstallDir; docker compose up -d"

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,8 @@
 # Flags:
 #   --dir <path>   — custom install directory
 #   --beta         — use :beta image tag instead of :latest
+#   --comfyui      — include ComfyUI image generation sidecar
+#   --trellis      — include TRELLIS 3D generation sidecar
 #   --no-start     — set up files but don't pull/start the container
 #   --no-open      — don't open the browser after starting
 #   --help         — show usage
@@ -21,6 +23,8 @@ TAG="latest"
 INSTALL_DIR="${OTTERBOT_DIR:-$HOME/otterbot}"
 NO_START=0
 NO_OPEN=0
+INCLUDE_COMFYUI=0
+INCLUDE_TRELLIS=0
 
 # ── Colours (disabled when not a tty) ────────────────────────────────────────
 
@@ -52,6 +56,8 @@ Usage:
 Options:
   --dir <path>   Install directory (default: \$HOME/otterbot)
   --beta         Use the beta image tag
+  --comfyui      Include ComfyUI image generation sidecar
+  --trellis      Include TRELLIS 3D generation sidecar
   --no-start     Generate files but don't start the container
   --no-open      Don't open the browser after starting
   --help         Show this help message
@@ -119,6 +125,12 @@ while [ $# -gt 0 ]; do
     --beta)
       TAG="beta"
       ;;
+    --comfyui)
+      INCLUDE_COMFYUI=1
+      ;;
+    --trellis)
+      INCLUDE_TRELLIS=1
+      ;;
     --no-start)
       NO_START=1
       ;;
@@ -151,8 +163,14 @@ case "$OS" in
 esac
 
 case "$ARCH" in
-  x86_64|amd64)  ARCH_NAME="x86_64" ;;
-  aarch64|arm64) ARCH_NAME="arm64" ;;
+  x86_64|amd64)
+    ARCH_NAME="x86_64"
+    DOCKER_PLATFORM="linux/amd64"
+    ;;
+  aarch64|arm64)
+    ARCH_NAME="arm64"
+    DOCKER_PLATFORM="linux/arm64"
+    ;;
   *)
     error "Unsupported architecture: $ARCH"
     exit 1
@@ -271,10 +289,22 @@ fi
 
 # ── Generate docker-compose.yml ──────────────────────────────────────────────
 
+# Build extra environment variables for otterbot service when sidecars are enabled
+EXTRA_ENV=""
+if [ "$INCLUDE_COMFYUI" -eq 1 ]; then
+  EXTRA_ENV="${EXTRA_ENV}
+      - OTTERBOT_COMFYUI_URL=http://comfyui:8188"
+fi
+if [ "$INCLUDE_TRELLIS" -eq 1 ]; then
+  EXTRA_ENV="${EXTRA_ENV}
+      - OTTERBOT_TRELLIS_URL=http://trellis:8080"
+fi
+
 cat > "$INSTALL_DIR/docker-compose.yml" <<EOF
 services:
   otterbot:
     image: ${IMAGE}:${TAG}
+    platform: ${DOCKER_PLATFORM}
     shm_size: "256m"
     ports:
       - "\${PORT:-62626}:62626"
@@ -287,11 +317,56 @@ services:
       - ENABLE_DESKTOP=\${ENABLE_DESKTOP:-true}
       - DESKTOP_RESOLUTION=\${DESKTOP_RESOLUTION:-1280x720x24}
       - SUDO_MODE=\${SUDO_MODE:-restricted}
-      - OTTERBOT_ALLOWED_ORIGIN=\${OTTERBOT_ALLOWED_ORIGIN:-}
+      - OTTERBOT_ALLOWED_ORIGIN=\${OTTERBOT_ALLOWED_ORIGIN:-}${EXTRA_ENV}
     restart: unless-stopped
 EOF
 
-info "Generated docker-compose.yml (image tag: ${TAG})"
+# Append ComfyUI sidecar service
+if [ "$INCLUDE_COMFYUI" -eq 1 ]; then
+  cat >> "$INSTALL_DIR/docker-compose.yml" <<EOF
+
+  comfyui:
+    image: ghcr.io/toosmooth/otterbot-comfyui:${TAG}
+    platform: ${DOCKER_PLATFORM}
+    environment:
+      - CLI_ARGS=--listen 0.0.0.0 --port 8188
+      - COMFYUI_DATA_ROOT=/data
+    volumes:
+      - \${OTTERBOT_DATA_DIR:-./data}/comfyui:/data
+    expose:
+      - "8188"
+    restart: unless-stopped
+EOF
+fi
+
+# Append TRELLIS sidecar service
+if [ "$INCLUDE_TRELLIS" -eq 1 ]; then
+  cat >> "$INSTALL_DIR/docker-compose.yml" <<EOF
+
+  trellis:
+    image: ghcr.io/toosmooth/otterbot-trellis:${TAG}
+    platform: ${DOCKER_PLATFORM}
+    environment:
+      - TRELLIS_DATA_ROOT=/data
+      - TRELLIS_PORT=8080
+      - TRELLIS_MODEL_REF=microsoft/TRELLIS-image-large
+      - TRELLIS_INFERENCE_CMD=
+      - ENABLE_BLENDER_POSTPROCESS=true
+    volumes:
+      - \${OTTERBOT_DATA_DIR:-./data}/trellis:/data
+    expose:
+      - "8080"
+    restart: unless-stopped
+EOF
+fi
+
+SIDECARS_MSG=""
+if [ "$INCLUDE_COMFYUI" -eq 1 ] || [ "$INCLUDE_TRELLIS" -eq 1 ]; then
+  SIDECARS_MSG=" + sidecars:"
+  [ "$INCLUDE_COMFYUI" -eq 1 ] && SIDECARS_MSG="${SIDECARS_MSG} comfyui"
+  [ "$INCLUDE_TRELLIS" -eq 1 ] && SIDECARS_MSG="${SIDECARS_MSG} trellis"
+fi
+info "Generated docker-compose.yml (image tag: ${TAG}, platform: ${DOCKER_PLATFORM}${SIDECARS_MSG})"
 
 # ── Pull & start ─────────────────────────────────────────────────────────────
 
@@ -313,6 +388,12 @@ printf "\n"
 printf "  %-12s %s\n" "URL:" "https://localhost:62626  (self-signed certificate)"
 printf "  %-12s %s\n" "Data:" "$INSTALL_DIR/data"
 printf "  %-12s %s\n" "Config:" "$INSTALL_DIR/.env"
+if [ "$INCLUDE_COMFYUI" -eq 1 ]; then
+  printf "  %-12s %s\n" "ComfyUI:" "enabled (port 8188 internal)"
+fi
+if [ "$INCLUDE_TRELLIS" -eq 1 ]; then
+  printf "  %-12s %s\n" "TRELLIS:" "enabled (port 8080 internal)"
+fi
 printf "\n"
 printf "  %-12s %s\n" "Stop:" "cd $INSTALL_DIR && docker compose down"
 printf "  %-12s %s\n" "Start:" "cd $INSTALL_DIR && docker compose up -d"


### PR DESCRIPTION
## Summary

- Add `--comfyui` / `--trellis` flags to `install.sh`
- Add `-ComfyUI` / `-Trellis` switches to `install.ps1`
- Synced from otterbot repo (TOoSmOotH/otterbot#462)

## Test plan
- [x] `install.sh --comfyui --trellis --no-start` generates correct compose
- [x] `install.sh --no-start` remains backwards compatible
- [x] Scripts are identical to otterbot repo copies